### PR TITLE
fix(git): handle repositories with single commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yml-change-webhook-trigger",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "GitHub Action to detect YML changes and trigger webhooks",
   "main": "dist/index.js",
   "scripts": {

--- a/src/detect-changes.js
+++ b/src/detect-changes.js
@@ -17,7 +17,16 @@ function detectChanges(baseRef) {
       command = `git diff --name-only origin/${base || 'main'}...HEAD`;
     } else {
       // For push events, compare with the previous commit
-      command = 'git diff --name-only HEAD^';
+      // Check if there's more than one commit in the repository
+      try {
+        // Try to get the parent commit to see if it exists
+        execSync('git rev-parse HEAD^', { stdio: 'pipe' });
+        command = 'git diff --name-only HEAD^';
+      } catch (e) {
+        // If HEAD^ doesn't exist (only one commit), list all files in the repo
+        core.info('Repository has only one commit. Listing all YML files instead of diff.');
+        command = 'git ls-files';
+      }
     }
 
     core.debug(`Executing command: ${command}`);


### PR DESCRIPTION

# Pull Request Template

## Description

- Modifies the change detection logic to correctly handle repositories with only one commit
- Adds a fallback to 'git ls-files' when HEAD^ doesn't exist
- Increases version to 1.0.2 for release

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- Test in local computer



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
